### PR TITLE
Exiting the container does not trigger a

### DIFF
--- a/packages/@vue/eslint-config-typescript/index.js
+++ b/packages/@vue/eslint-config-typescript/index.js
@@ -13,8 +13,7 @@ module.exports = {
     'no-unused-vars': 'off',
     // https://github.com/eslint/typescript-eslint-parser/issues/445
     // 'typescript/no-unused-vars': 'error',
-    // https://github.com/vuejs/vue-cli/issues/1672
-    'space-infix-ops': 'off',
+
     // temporary fix for https://github.com/vuejs/vue-cli/issues/1922
     // very strange as somehow this rule gets different behaviors depending
     // on the presence of typescript-eslint-parser...


### PR DESCRIPTION
Now that the bug in typescript-eslint-parser has been fixed.