### PR TITLE
Fix typo in PerformanceInliner

### DIFF
--- a/packages/@vue/cli-plugin-babel/index.js
+++ b/packages/@vue/cli-plugin-babel/index.js
@@ -50,6 +50,7 @@ module.exports = (api, options) => {
             '@babel/core': require('@babel/core/package.json').version,
             '@vue/babel-preset-app': require('@vue/babel-preset-app/package.json').version,
             'babel-loader': require('babel-loader/package.json').version,
+            modern: !!process.env.VUE_CLI_MODERN_BUILD,
             browserslist: api.service.pkg.browserslist
           }, [
             'babel.config.js',

--- a/packages/@vue/cli-plugin-typescript/index.js
+++ b/packages/@vue/cli-plugin-typescript/index.js
@@ -30,7 +30,8 @@ module.exports = (api, options) => {
       loader: 'cache-loader',
       options: api.genCacheConfig('ts-loader', {
         'ts-loader': require('ts-loader/package.json').version,
-        'typescript': require('typescript/package.json').version
+        'typescript': require('typescript/package.json').version,
+        modern: !!process.env.VUE_CLI_MODERN_BUILD
       }, 'tsconfig.json')
     })
 

--- a/packages/@vue/cli-service/lib/PluginAPI.js
+++ b/packages/@vue/cli-service/lib/PluginAPI.js
@@ -147,7 +147,8 @@ class PluginAPI {
       partialIdentifier,
       'cli-service': require('../package.json').version,
       'cache-loader': require('cache-loader/package.json').version,
-      env: process.env,
+      env: process.env.NODE_ENV,
+      test: !!process.env.VUE_CLI_TEST,
       config: [
         fmtFunc(this.service.projectOptions.chainWebpack),
         fmtFunc(this.service.projectOptions.configureWebpack)
@@ -158,7 +159,14 @@ class PluginAPI {
       const readConfig = file => {
         const absolutePath = this.resolve(file)
         if (fs.existsSync(absolutePath)) {
-          return fs.readFileSync(absolutePath, 'utf-8')
+          if (absolutePath.endsWith('.js')) {
+            // should evaluate config scripts to reflect environment variable changes
+            try {
+              return JSON.stringify(require(absolutePath))
+            } catch (e) {
+              return fs.readFileSync(absolutePath, 'utf-8')
+            }
+          }
         }
       }
       if (!Array.isArray(configFiles)) {


### PR DESCRIPTION
This reverts commit 047872c25eee9f70b5e9e2a67eded2714556e2a7.
Fixes #3416.